### PR TITLE
Added rapid-response xblock load test

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -87,3 +87,4 @@ release-notes-checklist
 
 # Local files
 usernames.txt
+course_data.json

--- a/rapid_response/course_data.json.example
+++ b/rapid_response/course_data.json.example
@@ -1,0 +1,18 @@
+Copy this file to course_data.json in the same directory.
+Replace the contents with a JSON representation of all courses, blocks, and answers that
+you want the load test to submit against.
+
+Example course data JSON:
+
+[
+  {
+    "course_id": "course-v1:MIT+gsidebo000+2017_Summer",
+    "blocks": [
+      {
+        "id": "block-v1:MIT+gsidebo000+2017_Summer+type@problem+block@90b4d9682dfb4276b7be32f4d86092bd",
+        "choicegroup_id": "90b4d9682dfb4276b7be32f4d86092bd_2_1",
+        "answer_ids": ["choice_0", "choice_1", "choice_2", "choice_3"]
+      }
+    ]
+  }
+]

--- a/rapid_response/loadtest_rapid_response.py
+++ b/rapid_response/loadtest_rapid_response.py
@@ -1,0 +1,141 @@
+"""
+"""
+import random
+from locust import HttpLocust, TaskSet, task
+
+import settings
+
+
+def client_is_logged_into_edx(client):
+    return client.cookies.get('edxloggedin') == 'true'
+
+
+class ProblemSubmission(TaskSet):
+    """
+    """
+    course_data = None
+
+    def on_start(self):
+        """on_start is called before any task is scheduled """
+        self.course_data = self.parent.course_data
+
+    @staticmethod
+    def _get_answer_post_url(course_id, block_id):
+        return '/courses/{}/xblock/{}/handler/xmodule_handler/problem_check'.format(
+            course_id,
+            block_id
+        )
+
+    @staticmethod
+    def _answer_post_dict(choicegroup_id, answer_id):
+        return {'input_{}'.format(choicegroup_id): answer_id}
+
+    @task
+    def submit_answer(self):
+        """
+        """
+        # Stop this task if not logged in yet
+        if not client_is_logged_into_edx(self.client):
+            self.interrupt()
+        course_id = self.course_data['course_id']
+        block = random.choice(self.course_data['blocks'])
+        block_id = block['id']
+        choicegroup_id = block['choicegroup_id']
+        answer_id = random.choice(block['answer_ids'])
+        self.client.post(
+            self._get_answer_post_url(course_id, block_id),
+            data=self._answer_post_dict(choicegroup_id, answer_id),
+            headers={
+                'X-CSRFToken': self.client.cookies.get('csrftoken')
+            },
+            name='Problem Submission',
+        )
+
+    @task
+    def stop(self):
+        self.interrupt()
+
+
+class UserLogIn(TaskSet):
+    """
+    """
+    tasks = {ProblemSubmission: 5}
+    enrolled_users = None
+    username = None
+    course_data = None
+    pw = 'edx'
+
+    def on_start(self):
+        """on_start is called before any task is scheduled """
+        self.enrolled_users = self.parent.enrolled_users
+        self.username = random.choice(settings.USERNAMES_IN_EDX)
+        self.course_data = random.choice(settings.RAPID_RESPONSE_COURSE_DATA)
+
+    def _login(self):
+        # load the login form to get the token
+        initial_login_resp = self.client.get(
+            '/login',
+            name='Initial login request'
+        )
+        csrf_token = initial_login_resp.cookies.get('csrftoken')
+        # login edx
+        self.client.post(
+            '/user_api/v1/account/login_session/',
+            data={
+                'email': '{}@example.com'.format(self.username),
+                'password': self.pw,
+                'remember': 'false'
+            },
+            headers={
+                'Referer': '/login',
+                'X-CSRFToken': csrf_token
+            },
+            name='Actual login'
+        )
+
+    def _enroll(self):
+        course_id = self.course_data['course_id']
+        # Unenrolling before enrolling because edX throws an error when an enrolled
+        # user requests to enroll again.
+        for enrollment_action in ['unenroll', 'enroll']:
+            self.client.post(
+                '/change_enrollment',
+                data={
+                    'course_id': course_id,
+                    'enrollment_action': enrollment_action
+                },
+                headers={
+                    'X-CSRFToken': self.client.cookies.get('csrftoken')
+                },
+                name='Course Enrollment ({})'.format(enrollment_action),
+            )
+        self.enrolled_users.add(self.username)
+
+    @task
+    def login_and_enroll(self):
+        """
+        """
+        if not client_is_logged_into_edx(self.client):
+            self._login()
+        if not self.username in self.enrolled_users:
+            self._enroll()
+
+    @task
+    def stop(self):
+        self.interrupt()
+
+
+class UserBehavior(TaskSet):
+    tasks = [UserLogIn]
+    enrolled_users = set()
+
+
+class WebsiteUser(HttpLocust):
+    host = settings.LMS_BASE_URL
+    task_set = UserBehavior
+    min_wait = settings.LOCUST_TASK_MIN_WAIT
+    max_wait = settings.LOCUST_TASK_MAX_WAIT
+
+
+if __name__ == "__main__":
+    WebsiteUser().run()

--- a/rapid_response/settings.py
+++ b/rapid_response/settings.py
@@ -1,0 +1,36 @@
+"""
+"""
+import os
+import json
+
+
+def get_var(name, default=None):
+    """Return the settings in a the environment"""
+    return os.environ.get(name, default)
+
+
+# locust settings
+LOCUST_TASK_MIN_WAIT = int(get_var('LOCUST_TASK_MIN_WAIT', 1000))
+LOCUST_TASK_MAX_WAIT = int(get_var('LOCUST_TASK_MAX_WAIT', 3000))
+
+LMS_BASE_URL = get_var('LMS_BASE_URL', 'http://localhost:18000')
+
+usernames_in_edx_env = get_var('USERNAMES_IN_EDX')
+USERNAMES_IN_EDX = []
+# first try to load usernames from environment
+if usernames_in_edx_env:
+    USERNAMES_IN_EDX = [username.strip() for username in usernames_in_edx_env.split(',')]
+# otherwise load from file
+else:
+    with open(os.path.join(os.path.dirname(__file__), 'usernames.txt')) as user_file:
+        for username in user_file:
+            USERNAMES_IN_EDX.append(username.strip())
+
+course_data_env = get_var('RAPID_RESPONSE_COURSE_DATA')
+RAPID_RESPONSE_COURSE_DATA = []
+# first try to load course data JSON from environment
+if course_data_env:
+    RAPID_RESPONSE_COURSE_DATA = json.loads(course_data_env.strip())
+else:
+    with open(os.path.join(os.path.dirname(__file__), 'course_data.json')) as course_data_file:
+        RAPID_RESPONSE_COURSE_DATA = json.load(course_data_file)

--- a/rapid_response/usernames.txt.example
+++ b/rapid_response/usernames.txt.example
@@ -1,0 +1,2 @@
+Copy this file to usernames.txt
+Replace all this text with a list of usernames existing in edx, one per row.


### PR DESCRIPTION
This new load test should be run against open edX with the `rapid-response-xblock` package installed. It relies on 2 external bits of data seeding on the open edX instance:

1. A set of users must be created on the instance, and the usernames for all of those users must be set as the value for the `USERNAMES_IN_EDX` env var (comma-separated) or added to `rapid_response/usernames.txt` (line-separated)
2. 1 or more courses must be created in the instance, each with at least 1 multiple choice block, and each block with 1 or more possible answers. A JSON representation of the data for the course(s) must be set in an environment variable (`RAPID_RESPONSE_COURSE_DATA`) or in a file at `rapid_response/course_data.json`. The format for that JSON can be found in [rapid_response/course_data.json.example](https://github.com/mitodl/locust-tests/blob/e29d972de70a47603a937d58f93482ff4904abf4/rapid_response/course_data.json.example)